### PR TITLE
build(docker): copy only postinstall script in prod image; add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Shrink Docker build context; safe to exclude these
+.git
+.github
+.DS_Store
+llm/**
+tests/**
+scripts/api/**
+

--- a/dockerfile
+++ b/dockerfile
@@ -24,9 +24,9 @@ FROM oven/bun:latest AS production
 
 WORKDIR /app
 
-# Copy package files (and required scripts)
+# Copy package files (and required postinstall script)
 COPY package.json bun.lock ./
-COPY scripts ./scripts
+COPY scripts/patch-zod-compat.mjs ./scripts/patch-zod-compat.mjs
 
 # Install only production dependencies
 RUN bun install --production --frozen-lockfile


### PR DESCRIPTION
## Description
build(docker): copy only postinstall script in prod image; add .dockerignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process by excluding version control, OS-specific, tests, and development directories from the build context, reducing transfer time and improving build performance for faster CI/CD pipelines.
  * Streamlined production image by copying only the necessary postinstall script instead of an entire scripts directory, decreasing image size and minimizing the runtime footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->