### PR TITLE
persist UI event logs to sqlite with pagination, lazy-load blobs, and export

### DIFF
--- a/frontend/components/EventLog.tsx
+++ b/frontend/components/EventLog.tsx
@@ -8,18 +8,39 @@ export interface EventLogProps {
   logs: LogEntryData[];
   isSignerRunning: boolean;
   onClearLogs: () => void;
+  onDownload?: () => void;
+  downloading?: boolean;
   hideHeader?: boolean;
   autoExpandTypes?: string[];
+  onLoadOlder?: () => void;
+  hasMore?: boolean;
+  loadingOlder?: boolean;
 }
 
-export const EventLog: React.FC<EventLogProps> = ({ logs, isSignerRunning, onClearLogs, hideHeader, autoExpandTypes }) => {
+export const EventLog: React.FC<EventLogProps> = ({
+  logs,
+  isSignerRunning,
+  onClearLogs,
+  onDownload,
+  downloading,
+  hideHeader,
+  autoExpandTypes,
+  onLoadOlder,
+  hasMore,
+  loadingOlder
+}) => {
   return (
     <UIEventLog
       logs={logs}
       isSignerRunning={isSignerRunning}
       onClearLogs={onClearLogs}
+      onDownload={onDownload}
+      downloading={downloading}
       hideHeader={hideHeader}
       autoExpandTypes={autoExpandTypes}
+      onLoadOlder={onLoadOlder}
+      hasMore={hasMore}
+      loadingOlder={loadingOlder}
     />
   );
 };

--- a/frontend/components/Signer.tsx
+++ b/frontend/components/Signer.tsx
@@ -73,9 +73,8 @@ const sanitizeLogEntry = (entry: unknown): LogEntryData | null => {
     type: log.type,
     message: log.message,
     data: log.data,
-    // Pass through persistence hints when present.
-    dataHash: (log as any).dataHash,
-    dataPreview: (log as any).dataPreview
+    dataHash: log.dataHash,
+    dataPreview: log.dataPreview
   };
 };
 

--- a/frontend/components/Signer.tsx
+++ b/frontend/components/Signer.tsx
@@ -44,11 +44,10 @@ const pulseStyle = `
 `;
 
 const DEFAULT_RELAY = "wss://relay.primal.net";
-const LOG_STORAGE_KEY = "igloo:event-log";
-const MAX_LOG_ENTRIES = 500;
+// UI event log history is persisted server-side in DB mode.
+// Keep a bounded in-memory buffer to prevent runaway memory usage; older entries remain queryable.
+const MAX_EVENT_LOG_IN_MEMORY = 10000;
 const AUTO_EXPAND_EVENT_TYPES: string[] = ['sign'];
-
-const canUseSessionStorage = () => typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
 
 const sanitizeLogEntry = (entry: unknown): LogEntryData | null => {
   if (!entry || typeof entry !== "object") return null;
@@ -73,48 +72,16 @@ const sanitizeLogEntry = (entry: unknown): LogEntryData | null => {
     timestamp,
     type: log.type,
     message: log.message,
-    data: log.data
+    data: log.data,
+    // Pass through persistence hints when present.
+    dataHash: (log as any).dataHash,
+    dataPreview: (log as any).dataPreview
   };
 };
 
-const readStoredLogs = (): LogEntryData[] => {
-  if (!canUseSessionStorage()) return [];
-
-  try {
-    const raw = window.sessionStorage.getItem(LOG_STORAGE_KEY);
-    if (!raw) return [];
-
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-
-    return parsed
-      .map(sanitizeLogEntry)
-      .filter((entry): entry is LogEntryData => entry !== null)
-      .slice(-MAX_LOG_ENTRIES);
-  } catch (error) {
-    console.warn("Failed to parse stored event logs:", error);
-    return [];
-  }
-};
-
-const writeStoredLogs = (entries: LogEntryData[]) => {
-  if (!canUseSessionStorage()) return;
-
-  if (entries.length === 0) {
-    window.sessionStorage.removeItem(LOG_STORAGE_KEY);
-    return;
-  }
-
-  try {
-    window.sessionStorage.setItem(LOG_STORAGE_KEY, JSON.stringify(entries));
-  } catch (error) {
-    console.warn("Failed to persist event logs:", error);
-  }
-};
-
-const clearStoredLogs = () => {
-  if (!canUseSessionStorage()) return;
-  window.sessionStorage.removeItem(LOG_STORAGE_KEY);
+const parseSeq = (id: string): number | null => {
+  const n = Number.parseInt(id, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
 };
 
 // Reusable deep validation helpers to avoid duplication
@@ -210,11 +177,17 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
     share: false
   });
   const [credentialSaveError, setCredentialSaveError] = useState<string | null>(null);
-  const [logs, setLogs] = useState<LogEntryData[]>(() => readStoredLogs());
+  const [logs, setLogs] = useState<LogEntryData[]>([]);
+  const [oldestSeq, setOldestSeq] = useState<number | null>(null);
+  const [hasMoreHistory, setHasMoreHistory] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [downloadingLogs, setDownloadingLogs] = useState(false);
   const [realSelfPubkey, setRealSelfPubkey] = useState<string | null>(null);
 
   // Reference for compatibility with parent component
   const nodeRef = useRef<any | null>(null);
+  const authHeadersRef = useRef(authHeaders);
+  useEffect(() => { authHeadersRef.current = authHeaders; }, [authHeaders]);
 
   // Expose methods to parent components through ref
   useImperativeHandle(ref, () => ({
@@ -416,11 +389,12 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
          const params = new URLSearchParams();
          
          // Check if we have auth headers and convert them to URL params
-         if (authHeaders['X-API-Key']) {
-           params.set('apiKey', authHeaders['X-API-Key']);
-         } else if (authHeaders['X-Session-ID']) {
-           params.set('sessionId', authHeaders['X-Session-ID']);
-         } else if (authHeaders['Authorization'] && authHeaders['Authorization'].startsWith('Basic ')) {
+         const currentAuth = authHeadersRef.current;
+         if (currentAuth['X-API-Key']) {
+           params.set('apiKey', currentAuth['X-API-Key']);
+         } else if (currentAuth['X-Session-ID']) {
+           params.set('sessionId', currentAuth['X-Session-ID']);
+         } else if (currentAuth['Authorization'] && currentAuth['Authorization'].startsWith('Basic ')) {
            // For basic auth, we'll rely on cookies or handle it server-side
            // The server should accept the connection if the user is already authenticated
          }
@@ -478,8 +452,8 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
               }
 
               const updated = [...prev, nextLog];
-              if (updated.length > MAX_LOG_ENTRIES) {
-                return updated.slice(updated.length - MAX_LOG_ENTRIES);
+              if (updated.length > MAX_EVENT_LOG_IN_MEMORY) {
+                return updated.slice(updated.length - MAX_EVENT_LOG_IN_MEMORY);
               }
               return updated;
             });
@@ -544,6 +518,104 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
       }
     };
   }, []);
+
+  // Load initial persisted history (DB mode). The realtime WebSocket continues to append new events.
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch('/api/event-log?limit=200', { headers: authHeaders });
+        if (!res.ok) {
+          if (res.status === 401) {
+            try { window.dispatchEvent(new CustomEvent('authExpired')); } catch {}
+          }
+          return;
+        }
+        const payload = await res.json();
+        const entries: unknown = (payload as any)?.entries;
+        const nextBeforeSeq: unknown = (payload as any)?.nextBeforeSeq;
+        if (!Array.isArray(entries)) return;
+        const sanitized = entries.map(sanitizeLogEntry).filter((e): e is LogEntryData => e !== null);
+        const chronological = [...sanitized].reverse();
+        if (cancelled) return;
+        setLogs(prev => {
+          if (prev.length === 0) return chronological;
+          const existing = new Set(prev.map(e => e.id));
+          const merged = [...chronological.filter(e => !existing.has(e.id)), ...prev];
+          return merged;
+        });
+        const seqs = chronological.map(e => parseSeq(e.id)).filter((n): n is number => n !== null);
+        const minSeq = seqs.length ? Math.min(...seqs) : null;
+        setOldestSeq(minSeq);
+        setHasMoreHistory(typeof nextBeforeSeq === 'number' ? nextBeforeSeq > 0 : chronological.length === 200);
+      } catch {
+        // Ignore history load errors; realtime stream still works.
+      }
+    };
+    if (!isHeadlessMode) {
+      void load();
+    }
+    return () => { cancelled = true; };
+  }, [authHeaders, isHeadlessMode]);
+
+  const handleLoadOlder = useCallback(async () => {
+    if (!oldestSeq || loadingOlder) return;
+    setLoadingOlder(true);
+    try {
+      const res = await fetch(`/api/event-log?limit=200&beforeSeq=${oldestSeq}`, { headers: authHeaders });
+      if (!res.ok) {
+        if (res.status === 401) {
+          try { window.dispatchEvent(new CustomEvent('authExpired')); } catch {}
+        }
+        return;
+      }
+      const payload = await res.json();
+      const entries: unknown = (payload as any)?.entries;
+      const nextBeforeSeq: unknown = (payload as any)?.nextBeforeSeq;
+      if (!Array.isArray(entries)) return;
+      const sanitized = entries.map(sanitizeLogEntry).filter((e): e is LogEntryData => e !== null);
+      const chronological = [...sanitized].reverse();
+      setLogs(prev => {
+        const existing = new Set(prev.map(e => e.id));
+        const merged = [...chronological.filter(e => !existing.has(e.id)), ...prev];
+        return merged;
+      });
+      const seqs = chronological.map(e => parseSeq(e.id)).filter((n): n is number => n !== null);
+      const minSeq = seqs.length ? Math.min(...seqs) : oldestSeq;
+      setOldestSeq(minSeq);
+      setHasMoreHistory(typeof nextBeforeSeq === 'number' ? nextBeforeSeq > 0 : chronological.length === 200);
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [oldestSeq, loadingOlder, authHeaders]);
+
+  const handleDownloadLogs = useCallback(async () => {
+    if (downloadingLogs) return;
+    setDownloadingLogs(true);
+    try {
+      const res = await fetch('/api/event-log/export', { headers: authHeaders });
+      if (!res.ok) {
+        if (res.status === 401) {
+          try { window.dispatchEvent(new CustomEvent('authExpired')); } catch {}
+        }
+        throw new Error('Failed to export logs');
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      a.href = url;
+      a.download = `igloo-event-log-${stamp}.ndjson`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => window.URL.revokeObjectURL(url), 500);
+    } catch (error) {
+      console.warn('Log export failed', error);
+    } finally {
+      setDownloadingLogs(false);
+    }
+  }, [authHeaders, downloadingLogs]);
 
   // Add effect to cleanup on unmount
   useEffect(() => {
@@ -929,14 +1001,11 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
     // Signer is managed by the server - no manual stop needed
   };
 
-  // Persist logs in session storage while component stays mounted
-  useEffect(() => {
-    writeStoredLogs(logs);
-  }, [logs]);
-
   const handleClearLogs = useCallback(() => {
-    clearStoredLogs();
+    // Audit log is persisted server-side; clearing only resets the current view.
     setLogs([]);
+    setOldestSeq(null);
+    setHasMoreHistory(false);
   }, []);
 
   // Show loading state while fetching environment variables
@@ -1254,6 +1323,11 @@ const Signer = forwardRef<SignerHandle, SignerProps>(({ initialData, authHeaders
           isSignerRunning={isSignerRunning}
           onClearLogs={handleClearLogs}
           autoExpandTypes={AUTO_EXPAND_EVENT_TYPES}
+          onLoadOlder={handleLoadOlder}
+          hasMore={hasMoreHistory}
+          loadingOlder={loadingOlder}
+          onDownload={handleDownloadLogs}
+          downloading={downloadingLogs}
         />
       </div>
     </div>

--- a/frontend/components/ui/UpdateBanner.tsx
+++ b/frontend/components/ui/UpdateBanner.tsx
@@ -10,7 +10,7 @@ interface UpdateBannerProps {
 }
 
 export const UpdateBanner: React.FC<UpdateBannerProps> = ({ info, className }) => {
-  if (!info || !info.enabled || !info.updateAvailable || !info.latestVersion) {
+  if (!info || !info.enabled || !info.updateAvailable || !info.currentVersion || !info.latestVersion) {
     return null;
   }
 

--- a/frontend/components/ui/event-log.tsx
+++ b/frontend/components/ui/event-log.tsx
@@ -3,7 +3,7 @@ import { IconButton } from "./icon-button";
 import { StatusIndicator } from "./status-indicator";
 import { Badge } from "./badge";
 import { Button } from "./button";
-import { Trash2, ChevronDown, ChevronUp, Filter, X } from "lucide-react";
+import { Trash2, ChevronDown, ChevronUp, Filter, X, Download } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { LogEntry, type LogEntryData } from "./log-entry";
 
@@ -11,18 +11,28 @@ interface EventLogProps {
   logs: LogEntryData[];
   isSignerRunning?: boolean;
   onClearLogs: () => void;
+  onDownload?: () => void;
+  downloading?: boolean;
   title?: string;
   hideHeader?: boolean;
   autoExpandTypes?: string[];
+  onLoadOlder?: () => void;
+  hasMore?: boolean;
+  loadingOlder?: boolean;
 }
 
 export const EventLog = memo(({
   logs,
   isSignerRunning = false,
   onClearLogs,
+  onDownload,
+  downloading = false,
   title = "Event Log",
   hideHeader = false,
-  autoExpandTypes = []
+  autoExpandTypes = [],
+  onLoadOlder,
+  hasMore = false,
+  loadingOlder = false
 }: EventLogProps) => {
   const logEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -131,6 +141,20 @@ export const EventLog = memo(({
       <span className="text-xs text-gray-500 italic">
         {isExpanded ? "Click to collapse" : "Click to expand"}
       </span>
+      {onDownload ? (
+        <IconButton
+          variant="default"
+          size="sm"
+          icon={<Download className="h-4 w-4" />}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDownload();
+          }}
+          tooltip={downloading ? "Downloading…" : "Download logs"}
+          disabled={downloading}
+          className="transition-all duration-200 hover:bg-gray-600/30"
+        />
+      ) : null}
       <IconButton
         variant="default"
         size="sm"
@@ -257,6 +281,23 @@ export const EventLog = memo(({
           </div>
         </div>
       )}
+
+      {isExpanded && onLoadOlder ? (
+        <div className="mt-2 flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onLoadOlder}
+            disabled={!hasMore || loadingOlder}
+            className="h-7 px-2 text-xs"
+          >
+            {loadingOlder ? 'Loading…' : hasMore ? 'Load older' : 'No more history'}
+          </Button>
+          <span className="text-[11px] text-gray-500">
+            History is persisted server-side in DB mode. Clearing only resets the current view.
+          </span>
+        </div>
+      ) : null}
       
       <div 
         className={cn(

--- a/frontend/components/ui/log-entry.tsx
+++ b/frontend/components/ui/log-entry.tsx
@@ -76,15 +76,18 @@ This is likely a complex object from the Bifrost node containing circular refere
 
 export const LogEntry = memo(({ log }: LogEntryProps) => {
   const [isMessageExpanded, setIsMessageExpanded] = React.useState(false);
-  const [resolvedData, setResolvedData] = React.useState<any>(log.data ?? log.dataPreview);
+  const [resolvedData, setResolvedData] = React.useState<any>(log.data ?? log.dataPreview ?? null);
   const [isLoadingData, setIsLoadingData] = React.useState(false);
-  const [hasFetchedFull, setHasFetchedFull] = React.useState(false);
+  const [hasFetchedFull, setHasFetchedFull] = React.useState(!!log.data);
+  const [fetchError, setFetchError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    if (!hasFetchedFull) {
-      setResolvedData(log.data ?? log.dataPreview);
-    }
-  }, [log.data, log.dataPreview, hasFetchedFull]);
+    // New log: reset derived state. Preview does not count as "full payload fetched".
+    setResolvedData(log.data ?? log.dataPreview ?? null);
+    setHasFetchedFull(!!log.data);
+    setFetchError(null);
+    setIsLoadingData(false);
+  }, [log.id, log.data, log.dataPreview, log.dataHash]);
 
   const hasData = !!(resolvedData && (typeof resolvedData !== 'object' || Object.keys(resolvedData).length > 0)) || !!log.dataHash;
 
@@ -96,11 +99,13 @@ export const LogEntry = memo(({ log }: LogEntryProps) => {
 
   React.useEffect(() => {
     if (!isMessageExpanded) return;
-    if (resolvedData !== undefined && resolvedData !== null) return;
+    if (hasFetchedFull) return;
+    if (fetchError) return; // Don't auto-retry while expanded; user can collapse + re-expand.
     const hash = typeof log.dataHash === 'string' ? log.dataHash : null;
     if (!hash || !/^[a-f0-9]{64}$/.test(hash)) return;
 
     let cancelled = false;
+    setFetchError(null);
     setIsLoadingData(true);
     fetch(`/api/event-log/blob/${hash}`)
       .then(res => res.ok ? res.json() : Promise.reject(new Error('Failed to fetch')))
@@ -113,8 +118,8 @@ export const LogEntry = memo(({ log }: LogEntryProps) => {
       })
       .catch(() => {
         if (cancelled) return;
-        // Keep UI usable even if blob fetch fails.
-        setResolvedData({ _error: 'failed_to_load_payload', hash });
+        // Keep UI usable even if blob fetch fails; preserve preview (if any) and surface a retry hint.
+        setFetchError('failed_to_load_payload');
       })
       .finally(() => {
         if (cancelled) return;
@@ -122,7 +127,16 @@ export const LogEntry = memo(({ log }: LogEntryProps) => {
       });
 
     return () => { cancelled = true; };
-  }, [isMessageExpanded, resolvedData, log.dataHash]);
+  }, [isMessageExpanded, hasFetchedFull, fetchError, log.dataHash]);
+
+  React.useEffect(() => {
+    // Allow retries: if expansion is collapsed after a fetch error, reset error/loading state.
+    if (isMessageExpanded) return;
+    if (!fetchError) return;
+    setFetchError(null);
+    setIsLoadingData(false);
+    setResolvedData(log.data ?? log.dataPreview ?? null);
+  }, [isMessageExpanded, fetchError, log.data, log.dataPreview]);
 
   const signatureSummary = React.useMemo(() => {
     const data = resolvedData;
@@ -140,8 +154,14 @@ export const LogEntry = memo(({ log }: LogEntryProps) => {
   const formattedData = React.useMemo(() => {
     if (!hasData) return null;
     if (isLoadingData) return 'Loading…';
+    if (fetchError) {
+      const preview = resolvedData !== undefined && resolvedData !== null
+        ? `\n\nPreview:\n${formatLogData(resolvedData)}`
+        : '';
+      return `Failed to load full payload. Collapse and re-expand to retry.${preview}`;
+    }
     return formatLogData(resolvedData);
-  }, [resolvedData, hasData, isLoadingData]);
+  }, [resolvedData, hasData, isLoadingData, fetchError]);
 
   return (
     <div className="mb-2 last:mb-0 bg-gray-800/40 p-2 rounded hover:bg-gray-800/50 transition-colors">

--- a/frontend/components/ui/log-entry.tsx
+++ b/frontend/components/ui/log-entry.tsx
@@ -9,6 +9,11 @@ export interface LogEntryData {
   message: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any;
+  // When persisted entries are listed without payloads, the UI can lazy-load by hash.
+  dataHash?: string | null;
+  // Optional small preview (may be truncated); used for quick inspection without fetching.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dataPreview?: any;
   id: string;
 }
 
@@ -71,7 +76,17 @@ This is likely a complex object from the Bifrost node containing circular refere
 
 export const LogEntry = memo(({ log }: LogEntryProps) => {
   const [isMessageExpanded, setIsMessageExpanded] = React.useState(false);
-  const hasData = log.data && Object.keys(log.data).length > 0;
+  const [resolvedData, setResolvedData] = React.useState<any>(log.data ?? log.dataPreview);
+  const [isLoadingData, setIsLoadingData] = React.useState(false);
+  const [hasFetchedFull, setHasFetchedFull] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!hasFetchedFull) {
+      setResolvedData(log.data ?? log.dataPreview);
+    }
+  }, [log.data, log.dataPreview, hasFetchedFull]);
+
+  const hasData = !!(resolvedData && (typeof resolvedData !== 'object' || Object.keys(resolvedData).length > 0)) || !!log.dataHash;
 
   const handleClick = useCallback(() => {
     if (hasData) {
@@ -79,22 +94,54 @@ export const LogEntry = memo(({ log }: LogEntryProps) => {
     }
   }, [hasData]);
 
+  React.useEffect(() => {
+    if (!isMessageExpanded) return;
+    if (resolvedData !== undefined && resolvedData !== null) return;
+    const hash = typeof log.dataHash === 'string' ? log.dataHash : null;
+    if (!hash || !/^[a-f0-9]{64}$/.test(hash)) return;
+
+    let cancelled = false;
+    setIsLoadingData(true);
+    fetch(`/api/event-log/blob/${hash}`)
+      .then(res => res.ok ? res.json() : Promise.reject(new Error('Failed to fetch')))
+      .then(payload => {
+        if (cancelled) return;
+        if (payload && typeof payload === 'object' && 'data' in payload) {
+          setResolvedData((payload as any).data);
+          setHasFetchedFull(true);
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Keep UI usable even if blob fetch fails.
+        setResolvedData({ _error: 'failed_to_load_payload', hash });
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoadingData(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [isMessageExpanded, resolvedData, log.dataHash]);
+
   const signatureSummary = React.useMemo(() => {
-    if (log.type !== 'sign' || !log.data) return null;
-    const session = typeof log.data.session === 'string' ? log.data.session : null;
-    const eventId = typeof log.data.eventId === 'string' ? log.data.eventId : null;
-    const kind = typeof log.data.kind === 'number' ? log.data.kind : null;
+    const data = resolvedData;
+    if (log.type !== 'sign' || !data) return null;
+    const session = typeof data.session === 'string' ? data.session : null;
+    const eventId = typeof data.eventId === 'string' ? data.eventId : null;
+    const kind = typeof data.kind === 'number' ? data.kind : null;
     const parts: string[] = [];
     if (session) parts.push(`session ${truncateMiddle(session)}`);
     if (kind != null) parts.push(`kind ${kind}`);
     if (eventId) parts.push(`event ${truncateMiddle(eventId)}`);
     return parts.length ? parts.join(' · ') : null;
-  }, [log]);
+  }, [log.type, resolvedData]);
 
   const formattedData = React.useMemo(() => {
     if (!hasData) return null;
-    return formatLogData(log.data);
-  }, [log.data, hasData]);
+    if (isLoadingData) return 'Loading…';
+    return formatLogData(resolvedData);
+  }, [resolvedData, hasData, isLoadingData]);
 
   return (
     <div className="mb-2 last:mb-0 bg-gray-800/40 p-2 rounded hover:bg-gray-800/50 transition-colors">

--- a/src/db/migrations/20260209_0001_ui_event_log.sql
+++ b/src/db/migrations/20260209_0001_ui_event_log.sql
@@ -1,0 +1,29 @@
+-- UI event log persistence (DB mode)
+-- Stores every UI-visible server log entry for backscroll + auditability.
+-- Payloads are de-duplicated by sha256 hash to reduce space without losing entries.
+
+CREATE TABLE IF NOT EXISTS ui_event_log_blobs (
+  hash TEXT PRIMARY KEY,
+  json TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS ui_event_log_entries (
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  created_at_ms INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  -- Optional payload reference (JSON stored in ui_event_log_blobs)
+  data_hash TEXT REFERENCES ui_event_log_blobs(hash),
+  data_preview TEXT,
+  data_bytes INTEGER,
+  -- Original event id emitted by the server (pre-persistence). Useful for debugging.
+  source_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_created_at_ms ON ui_event_log_entries(created_at_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_type_seq ON ui_event_log_entries(type, seq DESC);
+CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_seq ON ui_event_log_entries(seq DESC);
+

--- a/src/db/nip46.ts
+++ b/src/db/nip46.ts
@@ -338,21 +338,35 @@ export function getNip46RequestById(id: string): Nip46RequestRecord | null {
 
 export function listNip46Requests(
   userId: number | bigint,
-  opts?: { status?: Nip46RequestStatus[]; limit?: number }
+  opts?: {
+    status?: Nip46RequestStatus[]
+    limit?: number
+    before?: { createdAt: string; id: string }
+  }
 ): Nip46RequestRecord[] {
   const statuses = opts?.status && opts.status.length ? opts.status : null
   const limit = Math.min(Math.max(opts?.limit ?? 100, 1), 500)
+  const clauses: string[] = ['user_id = ?']
+  const params: any[] = [userId]
+
   if (statuses) {
     const placeholders = statuses.map(() => '?').join(',')
-    const stmt = db.prepare(
-      `SELECT * FROM nip46_requests WHERE user_id = ? AND status IN (${placeholders}) ORDER BY created_at DESC LIMIT ?`
-    )
-    return stmt.all(userId, ...statuses, limit) as Nip46RequestRecord[]
+    clauses.push(`status IN (${placeholders})`)
+    params.push(...statuses)
   }
+
+  const before = opts?.before
+  if (before && typeof before.createdAt === 'string' && typeof before.id === 'string' && before.createdAt.trim() && before.id.trim()) {
+    // Stable cursor using (created_at, id) tuple for deterministic pagination.
+    clauses.push('(created_at < ? OR (created_at = ? AND id < ?))')
+    params.push(before.createdAt, before.createdAt, before.id)
+  }
+
+  const whereSql = `WHERE ${clauses.join(' AND ')}`
   const stmt = db.prepare(
-    'SELECT * FROM nip46_requests WHERE user_id = ? ORDER BY created_at DESC LIMIT ?'
+    `SELECT * FROM nip46_requests ${whereSql} ORDER BY created_at DESC, id DESC LIMIT ?`
   )
-  return stmt.all(userId, limit) as Nip46RequestRecord[]
+  return stmt.all(...params, limit) as Nip46RequestRecord[]
 }
 
 export function updateNip46RequestStatus(

--- a/src/db/ui-event-log.test.ts
+++ b/src/db/ui-event-log.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { createUiEventLogStore, ensureUiEventLogSchema } from './ui-event-log.js'
+
+describe('ui-event-log store', () => {
+  test('appends entries, paginates by seq, and de-dupes blobs by hash', () => {
+    const mem = new Database(':memory:')
+    ensureUiEventLogSchema(mem)
+    const store = createUiEventLogStore(mem)
+
+    const commonData = { a: 1, b: 'x' }
+    const e1 = store.append({ type: 'info', message: 'one', data: commonData, timestamp: new Date().toISOString(), id: 'tmp1' })
+    const e2 = store.append({ type: 'info', message: 'two', data: commonData, timestamp: new Date().toISOString(), id: 'tmp2' })
+    const e3 = store.append({ type: 'error', message: 'three', data: { c: true }, timestamp: new Date().toISOString(), id: 'tmp3' })
+
+    expect(e1.seq).toBeGreaterThan(0)
+    expect(e2.seq).toBeGreaterThan(e1.seq)
+    expect(e3.seq).toBeGreaterThan(e2.seq)
+    expect(e1.dataHash).toBeTruthy()
+    expect(e2.dataHash).toBe(e1.dataHash)
+
+    const blobCount = mem.prepare('SELECT COUNT(*) as c FROM ui_event_log_blobs').get() as { c: number }
+    expect(blobCount.c).toBe(2)
+
+    const page1 = store.list({ limit: 2 })
+    expect(page1.entries.length).toBe(2)
+    expect(page1.entries[0].id).toBe(String(e3.seq))
+    expect(page1.entries[1].id).toBe(String(e2.seq))
+    expect(page1.nextBeforeSeq).toBe(e2.seq)
+
+    const page2 = store.list({ limit: 5, beforeSeq: page1.nextBeforeSeq ?? undefined })
+    expect(page2.entries.length).toBe(1)
+    expect(page2.entries[0].id).toBe(String(e1.seq))
+
+    const blob = store.getBlob(e1.dataHash!)
+    expect(blob).toBeTruthy()
+    expect((blob as any).data).toEqual(commonData)
+  })
+
+  test('redacts sensitive keys and truncates oversized payloads', () => {
+    const mem = new Database(':memory:')
+    ensureUiEventLogSchema(mem)
+    const store = createUiEventLogStore(mem)
+
+    const e1 = store.append({
+      type: 'info',
+      message: 'sensitive',
+      data: {
+        Authorization: 'Bearer SHOULD_NOT_PERSIST',
+        password: 'pw',
+        nested: { apiKey: 'key', ok: true }
+      },
+      timestamp: new Date().toISOString(),
+      id: 'tmp'
+    })
+
+    const blob1 = store.getBlob(e1.dataHash!)
+    expect(blob1).toBeTruthy()
+    const data1 = (blob1 as any).data as any
+    expect(data1.Authorization).toBe('[REDACTED]')
+    expect(data1.password).toBe('[REDACTED]')
+    expect(data1.nested.apiKey).toBe('[REDACTED]')
+    expect(data1.nested.ok).toBe(true)
+
+    const hugeObj: Record<string, string> = {}
+    for (let i = 0; i < 120; i++) {
+      hugeObj[`k${i}`] = 'x'.repeat(4096)
+    }
+    const e2 = store.append({
+      type: 'info',
+      message: 'huge',
+      data: hugeObj,
+      timestamp: new Date().toISOString(),
+      id: 'tmp2'
+    })
+    const blob2 = store.getBlob(e2.dataHash!)
+    expect(blob2).toBeTruthy()
+    const data2 = (blob2 as any).data as any
+    expect(data2._truncated).toBe(true)
+    expect(data2.originalBytes).toBeGreaterThan(200_000)
+    expect(typeof data2.originalSha256).toBe('string')
+    expect(typeof data2.preview).toBe('string')
+  })
+})

--- a/src/db/ui-event-log.ts
+++ b/src/db/ui-event-log.ts
@@ -1,0 +1,396 @@
+import { createHash } from 'node:crypto'
+import type { Database } from 'bun:sqlite'
+import db from './database.js'
+
+export type UiEventLogStreamEntry = {
+  type: string
+  message: string
+  data?: unknown
+  timestamp: string
+  id: string
+}
+
+export type UiEventLogListItem = {
+  seq: number
+  createdAt: string
+  createdAtMs: number
+  type: string
+  message: string
+  timestamp: string
+  id: string
+  dataHash: string | null
+  dataPreview: unknown | null
+  dataBytes: number | null
+}
+
+export type UiEventLogListResult = {
+  entries: UiEventLogListItem[]
+  nextBeforeSeq: number | null
+}
+
+export type UiEventLogExportRow = {
+  seq: number
+  createdAtMs: number
+  type: string
+  message: string
+  dataHash: string | null
+  dataBytes: number | null
+  data: unknown | null
+}
+
+function safeJsonStringify(value: unknown): string | null {
+  if (value === undefined) return null
+  try {
+    return JSON.stringify(value)
+  } catch {
+    try {
+      return JSON.stringify({ _error: 'non_serializable', preview: String(value) })
+    } catch {
+      return null
+    }
+  }
+}
+
+function sha256Hex(text: string): string {
+  return createHash('sha256').update(text).digest('hex')
+}
+
+const DATA_PREVIEW_MAX_BYTES = 2048
+const MAX_PERSISTED_DATA_BYTES = 200_000
+
+const REDACTED = '[REDACTED]'
+
+function looksSensitiveKey(key: string): boolean {
+  const k = key.trim().toLowerCase()
+  if (!k) return false
+  // Common secret-bearing keys. Keep this conservative: redact when we're confident.
+  if (k === 'authorization' || k === 'cookie' || k === 'set-cookie') return true
+  if (k === 'x-api-key' || k === 'api-key' || k === 'apikey' || k === 'api_key') return true
+  if (k === 'x-session-id' || k === 'session-id' || k === 'session_id' || k === 'sessionid') return true
+  if (k === 'password' || k === 'passwd' || k === 'pwd') return true
+  if (k === 'admin_secret' || k === 'adminsecret') return true
+  if (k === 'share_cred' || k === 'group_cred' || k === 'sharecred' || k === 'groupcred') return true
+  if (k === 'transport_sk' || k === 'transportkey' || k === 'transport_key') return true
+  if (k === 'session_secret' || k === 'sessionsecret') return true
+  if (k === 'derived_key' || k === 'derivedkey') return true
+  if (k.includes('secret') || k.includes('token')) return true
+  return false
+}
+
+function truncateString(value: string, max = 4096): string {
+  if (value.length <= max) return value
+  const head = value.slice(0, Math.max(0, max - 64))
+  const tail = value.slice(-48)
+  return `${head}…[truncated ${value.length - head.length - tail.length} chars]…${tail}`
+}
+
+function sanitizeForPersistence(value: unknown): unknown {
+  const seen = new WeakSet<object>()
+  const MAX_DEPTH = 10
+  const MAX_KEYS = 5000
+  const MAX_ARRAY = 5000
+
+  let keyCount = 0
+
+  const walk = (v: unknown, depth: number): unknown => {
+    if (v === null || v === undefined) return v
+    if (depth > MAX_DEPTH) return { _truncated: true, reason: 'max_depth' }
+
+    const t = typeof v
+    if (t === 'string') return truncateString(v)
+    if (t === 'number' || t === 'boolean') return v
+    if (t === 'bigint') return v.toString()
+    if (t === 'function' || t === 'symbol') return String(v)
+
+    if (v instanceof Error) {
+      return {
+        name: v.name,
+        message: v.message,
+        stack: typeof v.stack === 'string' ? truncateString(v.stack, 8192) : undefined,
+      }
+    }
+
+    if (Array.isArray(v)) {
+      const out: unknown[] = []
+      const n = Math.min(v.length, MAX_ARRAY)
+      for (let i = 0; i < n; i++) out.push(walk(v[i], depth + 1))
+      if (v.length > n) out.push({ _truncated: true, reason: 'max_array', originalLength: v.length })
+      return out
+    }
+
+    if (t === 'object') {
+      const obj = v as Record<string, unknown>
+      if (seen.has(obj)) return { _circular: true }
+      seen.add(obj)
+
+      const out: Record<string, unknown> = {}
+      for (const [k, rawVal] of Object.entries(obj)) {
+        keyCount++
+        if (keyCount > MAX_KEYS) {
+          out._truncated = true
+          out._truncatedReason = 'max_keys'
+          break
+        }
+        if (looksSensitiveKey(k)) {
+          out[k] = REDACTED
+          continue
+        }
+        out[k] = walk(rawVal, depth + 1)
+      }
+      return out
+    }
+
+    return String(v)
+  }
+
+  return walk(value, 0)
+}
+
+export function ensureUiEventLogSchema(dbConn: Database): void {
+  dbConn.exec(`
+    CREATE TABLE IF NOT EXISTS ui_event_log_blobs (
+      hash TEXT PRIMARY KEY,
+      json TEXT NOT NULL,
+      byte_length INTEGER NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `)
+  dbConn.exec(`
+    CREATE TABLE IF NOT EXISTS ui_event_log_entries (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      created_at_ms INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      data_hash TEXT REFERENCES ui_event_log_blobs(hash),
+      data_preview TEXT,
+      data_bytes INTEGER,
+      source_id TEXT
+    );
+  `)
+  dbConn.exec('CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_created_at_ms ON ui_event_log_entries(created_at_ms DESC)')
+  dbConn.exec('CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_type_seq ON ui_event_log_entries(type, seq DESC)')
+  dbConn.exec('CREATE INDEX IF NOT EXISTS idx_ui_event_log_entries_seq ON ui_event_log_entries(seq DESC)')
+}
+
+export function createUiEventLogStore(dbConn: Database) {
+  ensureUiEventLogSchema(dbConn)
+
+  const insertBlob = dbConn.prepare(`
+    INSERT OR IGNORE INTO ui_event_log_blobs (hash, json, byte_length)
+    VALUES (?, ?, ?)
+  `)
+
+  const insertEntry = dbConn.prepare(`
+    INSERT INTO ui_event_log_entries (
+      created_at_ms, type, message, data_hash, data_preview, data_bytes, source_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  const selectEntriesBase = (whereSql: string) => `
+    SELECT
+      seq,
+      created_at,
+      created_at_ms,
+      type,
+      message,
+      data_hash,
+      data_preview,
+      data_bytes
+    FROM ui_event_log_entries
+    ${whereSql}
+    ORDER BY seq DESC
+    LIMIT ?
+  `
+
+  const selectBlob = dbConn.prepare('SELECT json, byte_length FROM ui_event_log_blobs WHERE hash = ?')
+
+  return {
+    append(entry: UiEventLogStreamEntry): { seq: number; dataHash: string | null } {
+      const nowMs = Date.now()
+
+      const type = String(entry.type || '').trim() || 'info'
+      const message = String(entry.message || '').trim()
+
+      let dataHash: string | null = null
+      let dataPreview: string | null = null
+      let dataBytes: number | null = null
+
+      const sanitizedData = sanitizeForPersistence(entry.data)
+      const json = safeJsonStringify(sanitizedData)
+      if (json !== null) {
+        const bytes = Buffer.byteLength(json, 'utf8')
+        if (bytes > MAX_PERSISTED_DATA_BYTES) {
+          const originalSha256 = sha256Hex(json)
+          const summary = {
+            _truncated: true,
+            reason: 'max_persist_bytes',
+            originalBytes: bytes,
+            originalSha256,
+            preview: json.slice(0, DATA_PREVIEW_MAX_BYTES),
+          }
+          const summaryJson = safeJsonStringify(summary)
+          if (summaryJson) {
+            const summaryHash = sha256Hex(summaryJson)
+            insertBlob.run(summaryHash, summaryJson, Buffer.byteLength(summaryJson, 'utf8'))
+            dataHash = summaryHash
+            dataPreview = summaryJson
+            // Track original size for operators and UI.
+            dataBytes = bytes
+          }
+        } else {
+          dataBytes = bytes
+          dataHash = sha256Hex(json)
+          insertBlob.run(dataHash, json, dataBytes)
+          if (dataBytes <= DATA_PREVIEW_MAX_BYTES) {
+            dataPreview = json
+          } else {
+            dataPreview = json.slice(0, DATA_PREVIEW_MAX_BYTES)
+          }
+        }
+      }
+
+      const result = insertEntry.run(
+        nowMs,
+        type,
+        message,
+        dataHash,
+        dataPreview,
+        dataBytes,
+        entry.id ?? null
+      )
+
+      const seq = Number(result.lastInsertRowid)
+      return { seq, dataHash }
+    },
+
+    list(opts?: { limit?: number; beforeSeq?: number; types?: string[] }): UiEventLogListResult {
+      const limit = Math.min(Math.max(opts?.limit ?? 200, 1), 500)
+      const beforeSeq = opts?.beforeSeq
+      const types = opts?.types?.filter(t => typeof t === 'string' && t.trim().length > 0).map(t => t.trim()) ?? []
+
+      const clauses: string[] = []
+      const params: any[] = []
+
+      if (typeof beforeSeq === 'number' && Number.isFinite(beforeSeq) && beforeSeq > 0) {
+        clauses.push('seq < ?')
+        params.push(beforeSeq)
+      }
+
+      if (types.length > 0) {
+        const placeholders = types.map(() => '?').join(',')
+        clauses.push(`type IN (${placeholders})`)
+        params.push(...types)
+      }
+
+      const whereSql = clauses.length ? `WHERE ${clauses.join(' AND ')}` : ''
+      const stmt = dbConn.prepare(selectEntriesBase(whereSql))
+      const rows = stmt.all(...params, limit) as any[]
+
+      const entries: UiEventLogListItem[] = rows.map(r => {
+        const createdAtMs = typeof r.created_at_ms === 'number' ? r.created_at_ms : Number(r.created_at_ms)
+        if (!Number.isFinite(createdAtMs)) {
+          console.warn(`[ui-event-log] Invalid created_at_ms for seq=${r.seq}, falling back to Date.now()`)
+        }
+        const createdAtIso = Number.isFinite(createdAtMs) ? new Date(createdAtMs).toISOString() : String(r.created_at ?? '')
+        let preview: unknown | null = null
+        if (typeof r.data_preview === 'string' && r.data_preview.trim().length > 0) {
+          try { preview = JSON.parse(r.data_preview) } catch { preview = r.data_preview }
+        }
+        return {
+          seq: Number(r.seq),
+          createdAt: createdAtIso,
+          createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : Date.now(),
+          type: String(r.type ?? ''),
+          message: String(r.message ?? ''),
+          // Emit ISO timestamps so the browser can localize display consistently.
+          timestamp: createdAtIso,
+          id: String(r.seq),
+          dataHash: typeof r.data_hash === 'string' ? r.data_hash : null,
+          dataPreview: preview,
+          dataBytes: typeof r.data_bytes === 'number' ? r.data_bytes : (r.data_bytes == null ? null : Number(r.data_bytes)),
+        }
+      })
+
+      const nextBeforeSeq = entries.length === limit ? entries[entries.length - 1].seq : null
+      return { entries, nextBeforeSeq }
+    },
+
+    getBlob(hash: string): { data: unknown; byteLength: number } | null {
+      const key = (hash || '').trim().toLowerCase()
+      if (!/^[0-9a-f]{64}$/.test(key)) return null
+      const row = selectBlob.get(key) as { json: string; byte_length: number } | undefined
+      if (!row || typeof row.json !== 'string') return null
+      try {
+        return { data: JSON.parse(row.json), byteLength: row.byte_length }
+      } catch {
+        return { data: row.json, byteLength: row.byte_length }
+      }
+    }
+    ,
+
+    exportChunk(opts?: { afterSeq?: number; untilSeq?: number; limit?: number; types?: string[] }): { rows: UiEventLogExportRow[]; nextAfterSeq: number | null } {
+      const limit = Math.min(Math.max(opts?.limit ?? 1000, 1), 5000)
+      const afterSeq = typeof opts?.afterSeq === 'number' && Number.isFinite(opts.afterSeq) && opts.afterSeq >= 0 ? opts.afterSeq : 0
+      const untilSeq = typeof opts?.untilSeq === 'number' && Number.isFinite(opts.untilSeq) && opts.untilSeq > 0 ? opts.untilSeq : null
+      const types = opts?.types?.filter(t => typeof t === 'string' && t.trim().length > 0).map(t => t.trim()) ?? []
+
+      const clauses: string[] = ['e.seq > ?']
+      const params: any[] = [afterSeq]
+
+      if (untilSeq) {
+        clauses.push('e.seq <= ?')
+        params.push(untilSeq)
+      }
+
+      if (types.length > 0) {
+        const placeholders = types.map(() => '?').join(',')
+        clauses.push(`e.type IN (${placeholders})`)
+        params.push(...types)
+      }
+
+      const whereSql = `WHERE ${clauses.join(' AND ')}`
+      const stmt = dbConn.prepare(`
+        SELECT
+          e.seq as seq,
+          e.created_at_ms as created_at_ms,
+          e.type as type,
+          e.message as message,
+          e.data_hash as data_hash,
+          e.data_bytes as data_bytes,
+          b.json as data_json
+        FROM ui_event_log_entries e
+        LEFT JOIN ui_event_log_blobs b ON e.data_hash = b.hash
+        ${whereSql}
+        ORDER BY e.seq ASC
+        LIMIT ?
+      `)
+      const raw = stmt.all(...params, limit) as any[]
+      const rows: UiEventLogExportRow[] = raw.map(r => {
+        let parsed: unknown | null = null
+        if (typeof r.data_json === 'string' && r.data_json.length > 0) {
+          try { parsed = JSON.parse(r.data_json) } catch { parsed = r.data_json }
+        }
+        const createdAtMs = typeof r.created_at_ms === 'number' ? r.created_at_ms : Number(r.created_at_ms)
+        return {
+          seq: Number(r.seq),
+          createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : Date.now(),
+          type: String(r.type ?? ''),
+          message: String(r.message ?? ''),
+          dataHash: typeof r.data_hash === 'string' ? r.data_hash : null,
+          dataBytes: typeof r.data_bytes === 'number' ? r.data_bytes : (r.data_bytes == null ? null : Number(r.data_bytes)),
+          data: parsed
+        }
+      })
+      const nextAfterSeq = rows.length === limit ? rows[rows.length - 1].seq : null
+      return { rows, nextAfterSeq }
+    }
+  }
+}
+
+const defaultStore = createUiEventLogStore(db)
+
+export const appendUiEventLogEntry = defaultStore.append
+export const listUiEventLogEntries = defaultStore.list
+export const getUiEventLogBlob = defaultStore.getBlob
+export const exportUiEventLogChunk = defaultStore.exportChunk

--- a/src/db/ui-event-log.ts
+++ b/src/db/ui-event-log.ts
@@ -97,7 +97,7 @@ function sanitizeForPersistence(value: unknown): unknown {
     if (depth > MAX_DEPTH) return { _truncated: true, reason: 'max_depth' }
 
     const t = typeof v
-    if (t === 'string') return truncateString(v)
+    if (t === 'string') return truncateString(v as string)
     if (t === 'number' || t === 'boolean') return v
     if (t === 'bigint') return v.toString()
     if (t === 'function' || t === 'symbol') return String(v)

--- a/src/node/manager.ts
+++ b/src/node/manager.ts
@@ -90,11 +90,15 @@ const EVENT_MAPPINGS = {
   '/sign/rej': { type: 'sign', message: 'Signature request rejected' },
   '/sign/ret': { type: 'sign', message: 'Signature shares aggregated' },
   '/sign/err': { type: 'sign', message: 'Signature share aggregation failed' },
+  '/sign/sender/req': { type: 'sign', message: 'Signature request sent' },
+  '/sign/sender/res': { type: 'sign', message: 'Signature responses received' },
   '/ecdh/req': { type: 'ecdh', message: 'ECDH request received' },
   '/ecdh/res': { type: 'ecdh', message: 'ECDH response sent' },
   '/ecdh/rej': { type: 'ecdh', message: 'ECDH request rejected' },
   '/ecdh/ret': { type: 'ecdh', message: 'ECDH shares aggregated' },
   '/ecdh/err': { type: 'ecdh', message: 'ECDH share aggregation failed' },
+  '/ecdh/sender/req': { type: 'ecdh', message: 'ECDH request sent' },
+  '/ecdh/sender/res': { type: 'ecdh', message: 'ECDH responses received' },
   '/ping/req': { type: 'bifrost', message: 'Ping request' },
   '/ping/res': { type: 'bifrost', message: 'Ping response' },
 } as const;
@@ -1314,7 +1318,13 @@ export function createBroadcastEvent(eventStreams: Set<ServerWebSocket<EventStre
 }
 
 // Helper function to create a server log broadcaster
-export function createAddServerLog(broadcastEvent: ReturnType<typeof createBroadcastEvent>) {
+export function createAddServerLog(
+  broadcastEvent: ReturnType<typeof createBroadcastEvent>,
+  opts?: {
+    // Optional DB-mode persistence hook. Return a stable monotonic seq ID when persisted.
+    persist?: (entry: { type: string; message: string; data?: any; timestamp: string; id: string }) => number | null
+  }
+) {
   return function addServerLog(type: string, message: string, data?: any) {
     // Suppress noisy low‑value entries from the public event stream and console
     // - Signature aggregation events are very frequent and leak long IDs into UI
@@ -1325,20 +1335,34 @@ export function createAddServerLog(broadcastEvent: ReturnType<typeof createBroad
     ) {
       return; // do not log or broadcast
     }
-    const timestamp = new Date().toLocaleTimeString();
-    const logEntry = {
+    // Use ISO timestamp so browsers can localize display consistently.
+    const timestamp = new Date().toISOString();
+    const logEntry: { type: string; message: string; data?: any; timestamp: string; id: string; seq?: number } = {
       type,
       message,
       data,
       timestamp,
       id: Math.random().toString(36).substring(2, 11)
     };
+
+    // Persist first (when enabled) so the WS stream can carry a stable monotonic ID.
+    try {
+      const seq = opts?.persist?.(logEntry)
+      if (typeof seq === 'number' && Number.isFinite(seq) && seq > 0) {
+        logEntry.seq = seq
+        logEntry.id = String(seq)
+      }
+    } catch {
+      // Persistence is non-critical; fall back to ephemeral IDs.
+    }
     
     // Log to console for server logs
     if (data !== undefined && data !== null && data !== '') {
-      console.log(`[${timestamp}] ${type.toUpperCase()}: ${message}`, data);
+      const consoleTs = new Date().toLocaleTimeString();
+      console.log(`[${consoleTs}] ${type.toUpperCase()}: ${message}`, data);
     } else {
-      console.log(`[${timestamp}] ${type.toUpperCase()}: ${message}`);
+      const consoleTs = new Date().toLocaleTimeString();
+      console.log(`[${consoleTs}] ${type.toUpperCase()}: ${message}`);
     }
     
     // Broadcast to connected clients
@@ -1473,9 +1497,24 @@ export function setupNodeEventListeners(
         const messageData = msg as { tag: unknown; [key: string]: unknown };
         const tag = messageData.tag;
 
-        if (typeof tag === 'string') {
-          // Handle peer status updates for ping messages
-          if (tag === '/ping/req' || tag === '/ping/res') {
+          if (typeof tag === 'string') {
+            // Avoid double-logging for tags that also emit dedicated events with different signatures.
+            // These are logged by their dedicated handlers below.
+            if (
+              tag === '/sign/sender/rej' ||
+              tag === '/sign/sender/ret' ||
+              tag === '/sign/sender/err' ||
+              tag === '/sign/handler/rej' ||
+              tag === '/ecdh/sender/rej' ||
+              tag === '/ecdh/sender/ret' ||
+              tag === '/ecdh/sender/err' ||
+              tag === '/ecdh/handler/rej'
+            ) {
+              return
+            }
+
+            // Handle peer status updates for ping messages
+            if (tag === '/ping/req' || tag === '/ping/res') {
             // Extract pubkey from env.pubkey (Nostr event structure)
             let fromPubkey: string | undefined = undefined;
             
@@ -1646,28 +1685,8 @@ export function setupNodeEventListeners(
     node.on('/sign/sender/err', signSenderErrHandler);
     node.on('/sign/handler/rej', signHandlerRejHandler);
 
-    // Legacy direct event listeners for backward compatibility - only for events NOT handled by message handler
-    const legacyEvents = [
-      // Only include events that aren't already handled by EVENT_MAPPINGS via message handler
-      { event: '/ecdh/sender/req', type: 'ecdh', message: 'ECDH request sent' },
-      { event: '/ecdh/sender/res', type: 'ecdh', message: 'ECDH responses received' },
-      { event: '/sign/sender/req', type: 'sign', message: 'Signature request sent' },
-      { event: '/sign/sender/res', type: 'sign', message: 'Signature responses received' },
-      // Note: Removed /ecdh/handler/req, /ecdh/handler/res, /sign/handler/req, /sign/handler/res 
-      // because they're already handled by the message handler via EVENT_MAPPINGS
-    ];
-
-    legacyEvents.forEach(({ event, type, message }) => {
-      try {
-        const handler = (msg: unknown) => {
-          updateNodeActivity(addServerLog);
-          addServerLog(type, message, msg);
-        };
-        (node as any).on(event, handler);
-      } catch (e) {
-        // Silently ignore if event doesn't exist
-      }
-    });
+    // Legacy direct event listeners removed.
+    // Sender req/res tags are mapped in EVENT_MAPPINGS so they are logged via the message handler.
   } catch (e) {
     addServerLog('bifrost', 'Error setting up some legacy event listeners', e);
   }

--- a/src/routes/event-log.ts
+++ b/src/routes/event-log.ts
@@ -5,7 +5,7 @@ import type { RouteContext, RequestAuth } from './types.js'
 function parseSeq(value: string | null): number | undefined {
   if (!value) return undefined
   const n = Number.parseInt(value, 10)
-  if (!Number.isFinite(n) || n < 0) return undefined
+  if (!Number.isFinite(n) || n <= 0) return undefined
   return n
 }
 

--- a/src/routes/event-log.ts
+++ b/src/routes/event-log.ts
@@ -1,0 +1,168 @@
+import { HEADLESS } from '../const.js'
+import { getSecureCorsHeaders, mergeVaryHeaders } from './utils.js'
+import type { RouteContext, RequestAuth } from './types.js'
+
+function parseSeq(value: string | null): number | undefined {
+  if (!value) return undefined
+  const n = Number.parseInt(value, 10)
+  if (!Number.isFinite(n) || n < 0) return undefined
+  return n
+}
+
+function parseLimit(value: string | null, fallback = 200): number {
+  if (!value) return fallback
+  const n = Number.parseInt(value, 10)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(Math.max(n, 1), 500)
+}
+
+function parseBeforeSeq(value: string | null): number | undefined {
+  if (!value) return undefined
+  const n = Number.parseInt(value, 10)
+  if (!Number.isFinite(n) || n <= 0) return undefined
+  return n
+}
+
+function parseTypes(value: string | null): string[] | undefined {
+  if (!value) return undefined
+  const parts = value.split(',').map(v => v.trim()).filter(Boolean)
+  return parts.length ? parts : undefined
+}
+
+export async function handleEventLogRoute(
+  req: Request,
+  url: URL,
+  _context: RouteContext,
+  _auth: RequestAuth | null
+): Promise<Response | null> {
+  if (!url.pathname.startsWith('/api/event-log')) return null
+
+  // DB-mode only
+  if (HEADLESS) {
+    return Response.json({ error: 'UI event log unavailable in headless mode' }, { status: 404 })
+  }
+
+  const corsHeaders = getSecureCorsHeaders(req)
+  const mergedVary = mergeVaryHeaders(corsHeaders)
+  const headers = {
+    'Content-Type': 'application/json',
+    ...corsHeaders,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-API-Key, X-Session-ID',
+    'Vary': mergedVary,
+  }
+
+  if (req.method === 'OPTIONS') return new Response(null, { status: 200, headers })
+
+  // GET /api/event-log?limit=200&beforeSeq=123&types=sign,error
+  if (url.pathname === '/api/event-log' && req.method === 'GET') {
+    const limit = parseLimit(url.searchParams.get('limit'), 200)
+    const beforeSeq = parseBeforeSeq(url.searchParams.get('beforeSeq'))
+    const types = parseTypes(url.searchParams.get('types'))
+
+    try {
+      const { listUiEventLogEntries } = await import('../db/ui-event-log.js')
+      const result = listUiEventLogEntries({ limit, beforeSeq, types })
+      return Response.json(result, { headers })
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[event-log] list error:', error)
+      }
+      return Response.json({ error: 'Failed to list event log entries' }, { status: 500, headers })
+    }
+  }
+
+  // GET /api/event-log/blob/<hash>
+  if (url.pathname.startsWith('/api/event-log/blob/') && req.method === 'GET') {
+    const hash = url.pathname.split('/').pop() || ''
+    try {
+      const { getUiEventLogBlob } = await import('../db/ui-event-log.js')
+      const blob = getUiEventLogBlob(hash)
+      if (!blob) return Response.json({ error: 'Not found' }, { status: 404, headers })
+      return Response.json({ hash, ...blob }, { headers })
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[event-log] blob error:', error)
+      }
+      return Response.json({ error: 'Failed to fetch event log payload' }, { status: 500, headers })
+    }
+  }
+
+  // GET /api/event-log/export?sinceSeq=1&untilSeq=9999&types=sign,error
+  if (url.pathname === '/api/event-log/export' && req.method === 'GET') {
+    const sinceSeq = parseSeq(url.searchParams.get('sinceSeq')) ?? 1
+    const untilSeq = parseSeq(url.searchParams.get('untilSeq'))
+    const types = parseTypes(url.searchParams.get('types'))
+
+    const exportHeaders = {
+      ...corsHeaders,
+      'Vary': mergedVary,
+      'Content-Type': 'application/x-ndjson',
+      'Cache-Control': 'no-store',
+      // Hint browsers to download.
+      'Content-Disposition': `attachment; filename="igloo-event-log-${new Date().toISOString().slice(0, 10)}.ndjson"`
+    }
+
+    try {
+      const { exportUiEventLogChunk } = await import('../db/ui-event-log.js')
+      const encoder = new TextEncoder()
+
+      let afterSeq = Math.max(0, sinceSeq - 1)
+      let done = false
+
+      const stream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            if (done) {
+              controller.close()
+              return
+            }
+
+            const chunk = exportUiEventLogChunk({
+              afterSeq,
+              untilSeq: untilSeq && untilSeq > 0 ? untilSeq : undefined,
+              limit: 1000,
+              types
+            })
+
+            if (!chunk.rows.length) {
+              done = true
+              controller.close()
+              return
+            }
+
+            for (const row of chunk.rows) {
+              const line = JSON.stringify({
+                seq: row.seq,
+                timestamp: new Date(row.createdAtMs).toISOString(),
+                type: row.type,
+                message: row.message,
+                dataHash: row.dataHash,
+                dataBytes: row.dataBytes,
+                data: row.data ?? undefined
+              }) + '\n'
+              controller.enqueue(encoder.encode(line))
+            }
+
+            afterSeq = chunk.rows[chunk.rows.length - 1].seq
+            if (chunk.nextAfterSeq === null) {
+              done = true
+            }
+          } catch (err) {
+            done = true
+            controller.error(err)
+          }
+        }
+      })
+
+      return new Response(stream, { status: 200, headers: exportHeaders })
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[event-log] export error:', error)
+      }
+      return Response.json({ error: 'Failed to export event log' }, { status: 500, headers })
+    }
+  }
+
+  return Response.json({ error: 'Not Found' }, { status: 404, headers })
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ export { handleSignRoute } from './sign.js';
 export { handleNip44Route } from './nip44.js';
 export { handleNip04Route } from './nip04.js';
 export { handleNip46Route } from './nip46.js';
+export { handleEventLogRoute } from './event-log.js';
 export { handleUpdateRoute } from './update.js';
 
 // Export types and utilities
@@ -25,6 +26,7 @@ import { handleSignRoute } from './sign.js';
 import { handleNip44Route } from './nip44.js';
 import { handleNip04Route } from './nip04.js';
 import { handleNip46Route } from './nip46.js';
+import { handleEventLogRoute } from './event-log.js';
 import { handleUpdateRoute } from './update.js';
 import { handleDocsRoute } from './docs.js';
 import { handleOnboardingRoute } from './onboarding.js';
@@ -311,6 +313,7 @@ export async function handleRequest(
   const routeHandlers = [
     handleStatusRoute,    // Allow unauthenticated for health checks
     handleUpdateRoute,
+    handleEventLogRoute,
     handlePeersRoute,
     handleSignRoute,
     handleNip44Route,

--- a/src/routes/nip46.ts
+++ b/src/routes/nip46.ts
@@ -293,8 +293,25 @@ export async function handleNip46Route(
       const statusFilter = parseStatusFilter(url.searchParams.get('status'))
       const limitParam = url.searchParams.get('limit')
       const limit = limitParam ? Math.min(Math.max(parseInt(limitParam, 10) || 100, 1), 500) : 100
-      const requests = listNip46Requests(userId, { status: statusFilter ?? undefined, limit })
-      return Response.json({ requests }, { headers })
+      const beforeCreatedAt = url.searchParams.get('beforeCreatedAt')?.trim() || ''
+      const beforeId = url.searchParams.get('beforeId')?.trim() || ''
+
+      // Require both or neither for cursor-based pagination
+      if ((beforeCreatedAt && !beforeId) || (!beforeCreatedAt && beforeId)) {
+        return Response.json(
+          { error: 'Both beforeCreatedAt and beforeId are required for pagination' },
+          { status: 400, headers }
+        )
+      }
+
+      const before = (beforeCreatedAt && beforeId)
+        ? { createdAt: beforeCreatedAt, id: beforeId }
+        : undefined
+      const requests = listNip46Requests(userId, { status: statusFilter ?? undefined, limit, before })
+      const nextCursor = requests.length === limit
+        ? { createdAt: requests[requests.length - 1]?.created_at, id: requests[requests.length - 1]?.id }
+        : null
+      return Response.json({ requests, nextCursor }, { headers })
     }
 
     if (req.method === 'POST') {

--- a/src/routes/update.ts
+++ b/src/routes/update.ts
@@ -85,6 +85,7 @@ function parseVersion(raw: string, allowPrerelease: boolean): ParsedVersion | nu
   const [core, prerelease] = withoutPrefix.split('-', 2);
   const parts = core.split('.');
   if (parts.length < 3) return null;
+  if (parts.some(p => p === '' || !/^\d+$/.test(p))) return null;
 
   const major = Number(parts[0]);
   const minor = Number(parts[1]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -215,7 +215,12 @@ const restartState = { blockedByCredentials: false };
 
 // Create event management functions
 const broadcastEvent = createBroadcastEvent(eventStreams);
-const addServerLog = createAddServerLog(broadcastEvent);
+let persistUiEventLogEntry: ((entry: { type: string; message: string; data?: any; timestamp: string; id: string }) => number | null) | null = null
+const addServerLog = createAddServerLog(broadcastEvent, {
+  persist: (entry) => {
+    try { return persistUiEventLogEntry?.(entry) ?? null } catch { return null }
+  }
+});
 // NIP-46 service only needed in database mode (perf optimization 3.3)
 if (!CONST.HEADLESS) {
   initNip46Service({
@@ -358,6 +363,21 @@ async function initializeDatabase(): Promise<void> {
   } catch (e: any) {
     // Log but don't fail - NIP-46 is not critical for startup
     console.error('⚠️  Failed to initialize NIP-46 database:', e?.message || e);
+  }
+
+  // Enable UI event log persistence in DB mode (non-critical; failures are tolerated).
+  try {
+    const uiLog = await import('./db/ui-event-log.js')
+    persistUiEventLogEntry = (entry) => {
+      try {
+        const result = uiLog.appendUiEventLogEntry(entry as any)
+        return result?.seq ?? null
+      } catch {
+        return null
+      }
+    }
+  } catch (e: any) {
+    console.error('⚠️  Failed to enable UI event log persistence:', e?.message || e)
   }
 
   // Initialize persistent rate limiter with database connection

--- a/tests/routes/event-log.spec.ts
+++ b/tests/routes/event-log.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { runRouteScript, PROJECT_ROOT } from './helpers/script-runner';
+
+describe('Event log routes', () => {
+  test('route unavailable in headless mode', () => {
+    const script = `
+      const root = ${JSON.stringify(PROJECT_ROOT)};
+      process.env.NODE_ENV = 'test';
+      process.env.HEADLESS = 'true';
+
+      const { handleEventLogRoute } = await import(root + 'src/routes/event-log.ts');
+      const context = {
+        node: null,
+        addServerLog: () => {},
+        broadcastEvent: () => {},
+        peerStatuses: new Map(),
+        eventStreams: new Set(),
+        restartState: { blockedByCredentials: false },
+      };
+
+      const req = new Request('http://localhost/api/event-log?limit=1');
+      const res = await handleEventLogRoute(req, new URL(req.url), context, { authenticated: true, userId: 1 });
+      const body = await res.json();
+      console.log('@@RESULT@@' + JSON.stringify({ status: res.status, body }));
+      process.exit(0);
+    `;
+
+    const result = runRouteScript(script);
+    expect(result.status).toBe(404);
+    expect(result.body?.error).toContain('headless');
+  });
+});
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-persisted event log with "Load older" pagination and downloadable export
  * On-demand lazy loading of large log payloads when expanding entries

* **Improvements**
  * More reliable real-time log streaming with reconnection and deduplication
  * Safer and stricter version parsing; improved paginated queries and export behavior

* **Tests**
  * New route and store tests covering event log behavior, pagination, and export
<!-- end of auto-generated comment: release notes by coderabbit.ai -->